### PR TITLE
large tests: increased minimum block time to 10 seconds. maybe that a…

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -227,7 +227,7 @@
         "initialValidatorsCount": 1,
         "nodesCount": 30,
         "hbbftArgs": {
-          "minimumBlockTime": 1,
+          "minimumBlockTime": 10,
           "maximumBlockTime": 120
         },
         "contractArgs": {


### PR DESCRIPTION
…llows slow machines to keep up and not to drop out because of failing key gens.